### PR TITLE
Install and configure artifacts-credhelper

### DIFF
--- a/src/external-repository/NOTES.md
+++ b/src/external-repository/NOTES.md
@@ -64,6 +64,13 @@ to install a "telemetrySource" for git commits within the Codespace. This offers
 * `name`: changes the user name in the git configuration to `Existing Name (Codespaces)`
 * `email`: changes the email address in the git configuration to `existing+codespaces@domain.com`
 
+## Azure Artifacts Support
+
+When the provider is `azuredevops` this feature installs [Azure Artifacts Credential Provider](https://github.com/microsoft/artifacts-credprovider)
+and creates an alias for the `dotnet` command that will configure nuget authentication to use the same token
+used for Git, including the one obtained by the VS Code extension. This should allow nuget to install packages
+from a private feed without any additional user authentication required.
+
 ## OS Support
 
 This feature is tested to work with Debian, Ubuntu and Mariner for the Codespaces base image

--- a/src/external-repository/devcontainer-feature.json
+++ b/src/external-repository/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "External Git Repository in Codespace",
     "id": "external-repository",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Configures Codespace to work with an external Git repository",
     "options": {
         "gitProvider": {

--- a/src/external-repository/install.sh
+++ b/src/external-repository/install.sh
@@ -33,6 +33,7 @@ chmod +r /usr/local/external-repository-feature
 cp ./scripts/clone.sh /usr/local/external-repository-feature
 cp ./scripts/setup-user.sh /usr/local/external-repository-feature
 cp ./scripts/commit-msg.sh /usr/local/external-repository-feature
+cp ./scripts/run-dotnet.sh /usr/local/external-repository-feature
 
 # Write the variables.sh script
 echo "EXT_GIT_PROVIDER=\"${EXT_GIT_PROVIDER}\"" > /usr/local/external-repository-feature/variables.sh

--- a/src/external-repository/scripts/clone.sh
+++ b/src/external-repository/scripts/clone.sh
@@ -17,13 +17,18 @@ if [[ "${EXT_GIT_LOCAL_PATH}" == "" ]]; then
     exit 0;
 fi
 
+# Install artifacts-credprovider
+if [ "${EXT_GIT_PROVIDER}" = "azuredevops" ]; then
+    wget -qO- https://aka.ms/install-artifacts-credprovider.sh | bash
+fi
+
 if [[ "${EXT_GIT_PREBUILD_PAT}" == "" ]]; then
     echo "Prebuild secret is not set, attempting to clone with ado-auth-helper"
     if [ ! -f ${HOME}/ado-auth-helper ]; then
-        echo "Waiting up to 60 seconds for ado-auth-helper extension to be installed"
+        echo "Waiting up to 180 seconds for ado-auth-helper extension to be installed"
     fi    
-    # Wait up to 1 minute for the ado-auth-helper to be installed
-    for i in {1..60}; do
+    # Wait up to 3 minutes for the ado-auth-helper to be installed
+    for i in {1..180}; do
         if [ -f ${HOME}/ado-auth-helper ]; then
             break
         fi

--- a/src/external-repository/scripts/run-dotnet.sh
+++ b/src/external-repository/scripts/run-dotnet.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+source /usr/local/external-repository-feature/variables.sh
+
+# Find out if user configured a PAT for ADO and use it if so
+EXT_GIT_PAT_VALUE=""
+if [[ "${EXT_GIT_USER_PAT}" != "" ]]; then
+    EXT_GIT_PAT_VALUE=${!EXT_GIT_USER_PAT}
+else
+    EXT_GIT_PAT_VALUE=""
+fi
+
+# Setup access token for nuget
+if [ "${EXT_GIT_PAT_VALUE}" = "" ]; then
+    export VSS_NUGET_ACCESSTOKEN=$(/home/vscode/ado-auth-helper get-access-token)
+else
+    export VSS_NUGET_ACCESSTOKEN=${EXT_GIT_PAT_VALUE}
+fi
+
+# If VSS_NUGET_URI_PREFIXES is not set, we will set it to the default value
+if [ "${VSS_NUGET_URI_PREFIXES}" = "" ]; then
+    export VSS_NUGET_URI_PREFIXES=https://pkgs.dev.azure.com/
+fi
+
+dotnet "$@"
+
+unset VSS_NUGET_ACCESSTOKEN
+unset VSS_NUGET_URI_PREFIXES

--- a/src/external-repository/scripts/setup-user.sh
+++ b/src/external-repository/scripts/setup-user.sh
@@ -53,6 +53,18 @@ if grep -q "\[credential\]" "${GIT_PATH}/config"; then
     fi
 fi
 
+# Setup dotnet alias for Azure Artifacts to use same
+# authentication as git for nuget
+if [ "${EXT_GIT_PROVIDER}" = "azuredevops" ]; then
+    # Add alias for dotnet to bash and zsh
+    if [ -f ~/.bashrc ]; then
+        echo "alias dotnet='/usr/local/external-repository-feature/run-dotnet.sh'" >> ~/.bashrc
+    fi
+    if [ -f ~/.zshrc ]; then
+        echo "alias dotnet='/usr/local/external-repository-feature/run-dotnet.sh'" >> ~/.zshrc
+    fi
+fi
+
 if [ "$ADO" = "true" ]; then
     echo "Configuring ADO Authorization Helper"
     ADO_HELPER=$(echo ~)/ado-auth-helper


### PR DESCRIPTION
This adds an alias for dotnet to a script that sets up
to use the ADO PAT or Token from the extension
to authenticate the install of nuget packages