### PR TITLE
Add DevTool to PATH during install

### DIFF
--- a/src/devtool/devcontainer-feature.json
+++ b/src/devtool/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "DevTool",
     "id": "devtool",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Install DevTool",
     "installsAfter": [
         "ghcr.io/devcontainers/features/common-utils"

--- a/src/devtool/install.sh
+++ b/src/devtool/install.sh
@@ -65,16 +65,17 @@ EOF
 chmod 755 "$DEVTOOL_SCRIPT_PATH"
 
 # Setup PATH so that DevTool will be on PATH when the initial terminal is started
-
 if command -v sudo >/dev/null 2>&1; then
     if [ "root" != "$_REMOTE_USER" ]; then
-        sudo -u ${_REMOTE_USER} bash -c "echo 'export PATH=$PATH:~/.config/DevTool/CurrentVersion' >> ~/.bashrc"
-        sudo -u ${_REMOTE_USER} bash -c "echo 'export PATH=$PATH:~/.config/DevTool/CurrentVersion' >> ~/.zshrc"
+        echo "Adding DevTool to PATH for $_REMOTE_USER"
+        sudo -u ${_REMOTE_USER} bash -c 'echo "export PATH=\$PATH:$HOME/.config/DevTool/CurrentVersion" >> ~/.bashrc'
+        sudo -u ${_REMOTE_USER} bash -c 'echo "export PATH=\$PATH:$HOME/.config/DevTool/CurrentVersion" >> ~/.zshrc'
         exit 0
     fi
 fi
 
-echo "export PATH=$PATH:~/.config/DevTool/CurrentVersion" >> /etc/bash.bashrc || true
-echo "export PATH=$PATH:~/.config/DevTool/CurrentVersion" >> /etc/zsh/zshrc || true
+echo "Adding DevTool to PATH for root"
+echo 'export PATH=\$PATH:/root/.config/DevTool/CurrentVersion` >> /etc/bash.bashrc || true
+echo `export PATH=\$PATH:/root/.config/DevTool/CurrentVersion` >> /etc/zsh/zshrc || true
 
 exit 0

--- a/src/devtool/install.sh
+++ b/src/devtool/install.sh
@@ -49,7 +49,7 @@ EOF
 tee -a "$DEVTOOL_SCRIPT_PATH" > /dev/null \
 << 'EOF'
 
-echo "Installing DevTool..."
+echo "::step::Waiting for AzDO Authentication Helper..."
 # Wait up to 3 minutes for the ado-auth-helper to be installed
 for i in {1..180}; do
     if [ -f ${HOME}/ado-auth-helper ]; then
@@ -57,11 +57,24 @@ for i in {1..180}; do
     fi
     sleep 1
 done
-
+echo "::step::Installing DevTool..."
 cd /tmp
 curl -sL https://aka.ms/InstallToolLinux.sh | sh -s DevTool
 EOF
 
 chmod 755 "$DEVTOOL_SCRIPT_PATH"
+
+# Setup PATH so that DevTool will be on PATH when the initial terminal is started
+
+if command -v sudo >/dev/null 2>&1; then
+    if [ "root" != "$_REMOTE_USER" ]; then
+        sudo -u ${_REMOTE_USER} bash -c "echo 'export PATH=$PATH:~/.config/DevTool/CurrentVersion' >> ~/.bashrc"
+        sudo -u ${_REMOTE_USER} bash -c "echo 'export PATH=$PATH:~/.config/DevTool/CurrentVersion' >> ~/.zshrc"
+        exit 0
+    fi
+fi
+
+echo "export PATH=$PATH:~/.config/DevTool/CurrentVersion" >> /etc/bash.bashrc || true
+echo "export PATH=$PATH:~/.config/DevTool/CurrentVersion" >> /etc/zsh/zshrc || true
 
 exit 0

--- a/src/devtool/install.sh
+++ b/src/devtool/install.sh
@@ -75,7 +75,7 @@ if command -v sudo >/dev/null 2>&1; then
 fi
 
 echo "Adding DevTool to PATH for root"
-echo 'export PATH=\$PATH:/root/.config/DevTool/CurrentVersion` >> /etc/bash.bashrc || true
-echo `export PATH=\$PATH:/root/.config/DevTool/CurrentVersion` >> /etc/zsh/zshrc || true
+echo "export PATH=\$PATH:/root/.config/DevTool/CurrentVersion" >> /etc/bash.bashrc || true
+echo "export PATH=\$PATH:/root/.config/DevTool/CurrentVersion" >> /etc/zsh/zshrc || true
 
 exit 0

--- a/test/devtool/test.sh
+++ b/test/devtool/test.sh
@@ -6,7 +6,7 @@ set -e
 source dev-container-features-test-lib
 
 # Feature-specific tests
-check "devtool" grep "Devtool" <(cat ~/.bashrc)
+check "devtool" grep "DevTool" <(cat ~/.bashrc)
 
 # Report results
 # If any of the checks above exited with a non-zero exit code, the test will fail.

--- a/test/devtool/test.sh
+++ b/test/devtool/test.sh
@@ -6,8 +6,7 @@ set -e
 source dev-container-features-test-lib
 
 # Feature-specific tests
-check "devtool" cat /usr/local/share/install-devtool.sh
-
+check "devtool" grep "Devtool" <(cat ~/.bashrc)
 
 # Report results
 # If any of the checks above exited with a non-zero exit code, the test will fail.


### PR DESCRIPTION
This is so that it will be on PATH for the initial Terminal that is launched in a new Codespace