### PR TITLE
(feat) Support `rush` in artifacts-helper

### DIFF
--- a/src/artifacts-helper/NOTES.md
+++ b/src/artifacts-helper/NOTES.md
@@ -1,8 +1,8 @@
 This installs [Azure Artifacts Credential Provider](https://github.com/microsoft/artifacts-credprovider)
-and optionally configures an alias for `dotnet`, `nuget`, `npm`, and `yarn` that dynamically sets an authentication token
+and optionally configures an alias for `dotnet`, `nuget`, `npm`, `yarn`, and `rush` that dynamically sets an authentication token
 for pulling artifacts from a feed before running the command.
 
-For `npm` and `yarn` this requires that your `~/.npmrc` file is configured to use the ${ARTIFACTS_ACCESSTOKEN}
+For `npm`, `yarn`, and `rush` this requires that your `~/.npmrc` file is configured to use the ${ARTIFACTS_ACCESSTOKEN}
 environment variable for the `authToken`. A helper script has been added that you can use to write your `~/.npmrc`
 file during your setup process, though there are many ways you could accomplish this. To use the script, run it like
 this:

--- a/src/artifacts-helper/README.md
+++ b/src/artifacts-helper/README.md
@@ -22,6 +22,7 @@ Configures Codespace to authenticate with Azure Artifact feeds
 | npmAlias | Create alias for npm | boolean | true |
 | yarnAlias | Create alias for yarn | boolean | true |
 | npxAlias | Create alias for npx | boolean | true |
+| rushAlias | Create alias for rush | boolean | true |
 
 ## Customizations
 
@@ -30,10 +31,10 @@ Configures Codespace to authenticate with Azure Artifact feeds
 - `ms-codespaces-tools.ado-codespaces-auth`
 
 This installs [Azure Artifacts Credential Provider](https://github.com/microsoft/artifacts-credprovider)
-and optionally configures an alias for `dotnet`, `nuget`, `npm`, and `yarn` that dynamically sets an authentication token
+and optionally configures an alias for `dotnet`, `nuget`, `npm`, `yarn`, and `rush` that dynamically sets an authentication token
 for pulling artifacts from a feed before running the command.
 
-For `npm` and `yarn` this requires that your `~/.npmrc` file is configured to use the ${ARTIFACTS_ACCESSTOKEN}
+For `npm`, `yarn`, and `rush` this requires that your `~/.npmrc` file is configured to use the ${ARTIFACTS_ACCESSTOKEN}
 environment variable for the `authToken`. A helper script has been added that you can use to write your `~/.npmrc`
 file during your setup process, though there are many ways you could accomplish this. To use the script, run it like
 this:

--- a/src/artifacts-helper/devcontainer-feature.json
+++ b/src/artifacts-helper/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Azure Artifacts Credential Helper",
     "id": "artifacts-helper",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "Configures Codespace to authenticate with Azure Artifact feeds",
     "options": {
         "nugetURIPrefixes": {

--- a/src/artifacts-helper/devcontainer-feature.json
+++ b/src/artifacts-helper/devcontainer-feature.json
@@ -38,6 +38,11 @@
             "type": "boolean",
             "default": true,
             "description": "Create alias for npx"
+        },
+        "rushAlias": {
+            "type": "boolean",
+            "default": true,
+            "description": "Create alias for rush"
         }
     },
     "installsAfter": [

--- a/src/artifacts-helper/install.sh
+++ b/src/artifacts-helper/install.sh
@@ -9,6 +9,7 @@ ALIAS_NUGET="${NUGETALIAS:-"true"}"
 ALIAS_NPM="${NPMALIAS:-"true"}"
 ALIAS_YARN="${YARNALIAS:-"true"}"
 ALIAS_NPX="${NPXALIAS:-"true"}"
+ALIAS_RUSH="${RUSHALIAS:-"true"}"
 
 # Source /etc/os-release to get OS info
 . /etc/os-release
@@ -63,6 +64,11 @@ chmod +rx /usr/local/bin/write-npm.sh
 cp ./scripts/run-npx.sh /usr/local/bin/run-npx.sh
 chmod +rx /usr/local/bin/run-npx.sh
 
+cp ./scripts/run-rush.sh /usr/local/bin/run-rush.sh
+chmod +rx /usr/local/bin/run-rush.sh
+cp ./scripts/run-rush-pnpm.sh /usr/local/bin/run-rush-pnpm.sh
+chmod +rx /usr/local/bin/run-rush-pnpm.sh
+
 
 if command -v sudo >/dev/null 2>&1; then
     if [ "root" != "$_REMOTE_USER" ]; then
@@ -85,7 +91,14 @@ if command -v sudo >/dev/null 2>&1; then
         if [ "${ALIAS_NPX}" = "true" ]; then
             sudo -u ${_REMOTE_USER} bash -c "echo 'alias npx=/usr/local/bin/run-npx.sh' >> ~/.bashrc"
             sudo -u ${_REMOTE_USER} bash -c "echo 'alias npx=/usr/local/bin/run-npx.sh' >> ~/.zshrc"
-        fi        
+        fi
+        if [ "${ALIAS_RUSH}" = "true" ]; then
+            sudo -u ${_REMOTE_USER} bash -c "echo 'alias rush=/usr/local/bin/run-rush.sh' >> ~/.bashrc"
+            sudo -u ${_REMOTE_USER} bash -c "echo 'alias rush=/usr/local/bin/run-rush.sh' >> ~/.zshrc"
+
+            sudo -u ${_REMOTE_USER} bash -c "echo 'alias rush-pnpm=/usr/local/bin/run-rush-pnpm.sh' >> ~/.bashrc"
+            sudo -u ${_REMOTE_USER} bash -c "echo 'alias rush-pnpm=/usr/local/bin/run-rush-pnpm.sh' >> ~/.zshrc"
+        fi
         sudo -u ${_REMOTE_USER} bash -c "/tmp/install-provider.sh ${USENET6}"
         rm /tmp/install-provider.sh
         exit 0
@@ -115,6 +128,14 @@ fi
 if [ "${ALIAS_NPX}" = "true" ]; then
     sudo -u ${_REMOTE_USER} bash -c "echo 'alias npx=/usr/local/bin/run-npx.sh' >> /etc/bash.bashrc || true
     sudo -u ${_REMOTE_USER} bash -c "echo 'alias npx=/usr/local/bin/run-npx.sh' >> /etc/zsh/zshrc || true
+fi
+
+if [ "${ALIAS_RUSH}" = "true" ]; then
+    sudo -u ${_REMOTE_USER} bash -c "echo 'alias rush=/usr/local/bin/run-rush.sh' >> /etc/bash.bashrc || true
+    sudo -u ${_REMOTE_USER} bash -c "echo 'alias rush=/usr/local/bin/run-rush.sh' >> /etc/zsh/zshrc || true
+
+    sudo -u ${_REMOTE_USER} bash -c "echo 'alias rush-pnpm=/usr/local/bin/run-rush-pnpm.sh' >> /etc/bash.bashrc || true
+    sudo -u ${_REMOTE_USER} bash -c "echo 'alias rush-pnpm=/usr/local/bin/run-rush-pnpm.sh' >> /etc/zsh/zshrc || true
 fi
 
 rm /tmp/install-provider.sh

--- a/src/artifacts-helper/scripts/run-rush-pnpm.sh
+++ b/src/artifacts-helper/scripts/run-rush-pnpm.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ -f "${HOME}/ado-auth-helper" ]; then
+  export ARTIFACTS_ACCESSTOKEN=$(${HOME}/ado-auth-helper get-access-token)
+fi
+
+# Find the rush-pnpm executable so we do not run the bash alias again
+RUSH_PNPM_EXE=$(which rush-pnpm)
+
+${RUSH_PNPM_EXE} "$@"
+EXIT_CODE=$?
+unset RUSH_PNPM_EXE
+
+if [ -f "${HOME}/ado-auth-helper" ]; then
+    unset ARTIFACTS_ACCESSTOKEN
+fi
+
+exit $EXIT_CODE

--- a/src/artifacts-helper/scripts/run-rush.sh
+++ b/src/artifacts-helper/scripts/run-rush.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ -f "${HOME}/ado-auth-helper" ]; then
+  export ARTIFACTS_ACCESSTOKEN=$(${HOME}/ado-auth-helper get-access-token)
+fi
+
+# Find the rush executable so we do not run the bash alias again
+RUSH_EXE=$(which rush)
+
+${RUSH_EXE} "$@"
+EXIT_CODE=$?
+unset RUSH_EXE
+
+if [ -f "${HOME}/ado-auth-helper" ]; then
+    unset ARTIFACTS_ACCESSTOKEN
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
Adds support to the `artifacts-helper` feature for the `rush` binary, so that monorepos using Rush (which do not invoke the package manager directly from the command line) can benefit from the same authentication model.