### PR TITLE
fix(keyring): Fix install script and add tests

### DIFF
--- a/src/artifacts-helper/devcontainer-feature.json
+++ b/src/artifacts-helper/devcontainer-feature.json
@@ -51,7 +51,8 @@
         }        
     },
     "installsAfter": [
-        "ghcr.io/devcontainers/features/common-utils"
+        "ghcr.io/devcontainers/features/common-utils",
+        "ghcr.io/devcontainers/features/python"
     ],
     "customizations": {
         "vscode": {
@@ -59,5 +60,5 @@
                 "ms-codespaces-tools.ado-codespaces-auth"
             ]
         }
-    }    
+    }
 }

--- a/src/artifacts-helper/install.sh
+++ b/src/artifacts-helper/install.sh
@@ -73,6 +73,11 @@ cp ./scripts/run-rush-pnpm.sh /usr/local/bin/run-rush-pnpm.sh
 chmod +rx /usr/local/bin/run-rush-pnpm.sh
 
 
+if [ "${INSTALL_PIP_HELPER}" = "true" ]; then
+    USER="${_REMOTE_USER}" /tmp/install-python-keyring.sh
+    rm /tmp/install-python-keyring.sh
+fi
+
 if command -v sudo >/dev/null 2>&1; then
     if [ "root" != "$_REMOTE_USER" ]; then
         if [ "${ALIAS_DOTNET}" = "true" ]; then
@@ -104,10 +109,6 @@ if command -v sudo >/dev/null 2>&1; then
         fi
         sudo -u ${_REMOTE_USER} bash -c "/tmp/install-provider.sh ${USENET6}"
         rm /tmp/install-provider.sh
-        if [ "${INSTALL_PIP_HELPER}" = "true" ]; then
-            sudo -u ${_REMOTE_USER} bash -c "/tmp/install-python-keyring.sh"
-            rm /tmp/install-python-keyring.sh
-        fi
         exit 0
     fi
 fi
@@ -145,10 +146,6 @@ if [ "${ALIAS_RUSH}" = "true" ]; then
     sudo -u ${_REMOTE_USER} bash -c "echo 'alias rush-pnpm=/usr/local/bin/run-rush-pnpm.sh' >> /etc/zsh/zshrc || true
 fi
 
-if [ "${INSTALL_PIP_HELPER}" = "true" ]; then
-    bash -c "/tmp/install-python-keyring.sh"
-    rm /tmp/install-python-keyring.sh
-fi
 rm /tmp/install-provider.sh
 
 exit 0

--- a/src/artifacts-helper/scripts/install-python-keyring.sh
+++ b/src/artifacts-helper/scripts/install-python-keyring.sh
@@ -1,16 +1,67 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -e
+
+WHEEL_URL='https://github.com/microsoft/codespace-features/releases/download/latest/codespaces_artifacts_helper_keyring-0.1.0-py3-none-any.whl'
+WHEEL_DEST_FILENAME='codespaces_artifacts_helper_keyring-0.1.0-py3-none-any.whl'
 
 cd /tmp
-wget https://github.com/microsoft/codespace-features/releases/download/latest/codespaces_artifacts_helper_keyring-0.1.0-py3-none-any.whl
-if python3 -m pip &> /dev/null; then
-    python3 -m pip install codespaces_artifacts_helper_keyring-0.1.0-py3-none-any.whl
-elif command -v pip3 &> /dev/null; then
-    pip3 install codespaces_artifacts_helper_keyring-0.1.0-py3-none-any.whl
-elif python -m pip &> /dev/null; then
-    python -m pip install codespaces_artifacts_helper_keyring-0.1.0-py3-none-any.whl
-elif command -v pip &> /dev/null; then
-    pip install codespaces_artifacts_helper_keyring-0.1.0-py3-none-any.whl
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+    -h | --help)
+        echo "Usage: $(basename "$0") [(-u | --user) <user>] [-h | --help]
+
+Options:
+  -h --help             Show this screen.
+  -u USER, --user USER  Install for another user by specifying their name.
+                        Alternatively, set the USER environment variable.
+"
+        exit
+        ;;
+
+    -u | --user)
+        USER="$2"
+        shift
+        ;;
+
+    *)
+        echo "Unknown parameter passed: $1"
+        exit 1
+        ;;
+    esac
+    shift
+done
+
+# Find the path to the Python executable outside of sudo, to account for Python
+# not being present in the secure_path.
+if command -v python3 &>/dev/null; then
+    PYTHON_SRC=$(which python3)
+elif command -v python &>/dev/null; then
+    PYTHON_SRC=$(which python)
 else
-    echo "pip installation not detected. Artifacts Helper keyring not installed."
+    echo "Python not found. Artifacts Helper keyring not installed. whoami=$(whoami), PATH=$PATH"
     exit 1
 fi
+
+sudo_if_user() {
+    COMMAND="$*"
+    if [[ $USER ]]; then
+        if ! command -v sudo >/dev/null 2>&1; then
+            echo "The --user option was specified, but sudo could not be found."
+            exit 1
+        fi
+        sudo -u "$USER" bash -c "$COMMAND"
+    else
+        $COMMAND
+    fi
+}
+
+install_user_package() {
+    sudo_if_user "${PYTHON_SRC}" -m pip install --user --upgrade --no-cache-dir "$1"
+}
+
+wget "$WHEEL_URL" -O "$WHEEL_DEST_FILENAME"
+chmod a=r "$WHEEL_DEST_FILENAME" # Usually not needed, but helpful just in case
+install_user_package "$WHEEL_DEST_FILENAME"
+rm "$WHEEL_DEST_FILENAME"

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -5,7 +5,7 @@
             "microsoft-git": {
                 "version": "2.39.2.vfs.0.0"
             },
-            "artifacts-helper": {"python" : "true"},
+            "artifacts-helper": {},
             "external-repository": {
                 "gitProvider": "azuredevops",
                 "cloneUrl": "https://github.com/devcontainers/features",
@@ -33,7 +33,7 @@
                 "options": "--single-branch --no-src",
                 "scalar": "true"
             },
-            "artifacts-helper": {"python" : "true"}
+            "artifacts-helper": {}
         },
         "remoteEnv": {
             "EXT_GIT_PAT": "dummypat"

--- a/test/artifacts-helper/check_python_and_keyring.sh
+++ b/test/artifacts-helper/check_python_and_keyring.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib || exit 1
+
+# Confidence check for prerequisites
+check 'pip should be installed' python3 -m pip --version
+
+check 'keyring should be installed' python3 -m pip show keyring
+check 'codespaces_artifacts_helper_keyring should be installed' python3 -m pip show codespaces_artifacts_helper_keyring
+
+# Report results
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults

--- a/test/artifacts-helper/python312_and_keyring_debian.sh
+++ b/test/artifacts-helper/python312_and_keyring_debian.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+set -e
+./check_python_and_keyring.sh

--- a/test/artifacts-helper/python38_and_keyring_debian.sh
+++ b/test/artifacts-helper/python38_and_keyring_debian.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+set -e
+./check_python_and_keyring.sh

--- a/test/artifacts-helper/python38_and_keyring_ubuntu.sh
+++ b/test/artifacts-helper/python38_and_keyring_ubuntu.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+set -e
+./check_python_and_keyring.sh

--- a/test/artifacts-helper/python_and_no_keyring.sh
+++ b/test/artifacts-helper/python_and_no_keyring.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib || exit 1
+
+# Confidence check for prerequisites
+check 'pip should be installed' bash -c 'python3 -m pip --version'
+
+check 'codespaces_artifacts_helper_keyring should not be installed' bash -c '! python3 -m pip show codespaces_artifacts_helper_keyring'
+
+# Report results
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults

--- a/test/artifacts-helper/scenarios.json
+++ b/test/artifacts-helper/scenarios.json
@@ -1,0 +1,46 @@
+{
+    "python38_and_keyring_debian": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "ghcr.io/devcontainers/features/python:1": {
+                "version": "3.8"
+            },
+            "artifacts-helper": {
+                "python": true
+            }
+        }
+    },
+    "python38_and_keyring_ubuntu": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "ghcr.io/devcontainers/features/python:1": {
+                "version": "3.8"
+            },
+            "artifacts-helper": {
+                "python": true
+            }
+        }
+    },
+    "python312_and_keyring_debian": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "ghcr.io/devcontainers/features/python:1": {
+                "version": "3.12"
+            },
+            "artifacts-helper": {
+                "python": true
+            }
+        }
+    },
+    "python_and_no_keyring": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "ghcr.io/devcontainers/features/python:1": {
+                "version": "3.8"
+            },
+            "artifacts-helper": {
+                "python": false
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Python Keyring Installation Script
Here's my approach to fixing the issues with the keyring installation script. Feel free to take your own approach, as I've explained the main causes of the issue below. I've also included extra tests that you may find helpful.

### Fixing Python Not Found
Currently, the global test on Debian and Ubuntu are failing ([logs](https://github.com/microsoft/codespace-features/actions/runs/9098680497/job/25009440567#step:4:867)) because the keyring package installation script can't find Python or pip on the PATH.

I've found that there are two main causes for this. 
1. The devcontainer feature could be installed before Python is installed. So we add the Python feature to artifacts-helper's `installsAfter` spec.
```diff
 "installsAfter": [
     "ghcr.io/devcontainers/features/common-utils",
+    "ghcr.io/devcontainers/features/python"
 ],
```

2. Using `sudo` on some systems (namely the Debian and Ubuntu base images, but not the Python image) will cause the `PATH` to be changed to a [`secure_path`](https://www.sudo.ws/docs/man/sudoers.man/#SUDOERS_OPTIONS), which may not contain Python or pip.
The installation of the keyring package currently fails because we call python as the remote user like so,
    ```sh
    # These two will fail because Python and pip are not on the `secure_path`
    sudo -u USER bash -c "python -m pip install ..."
    sudo -u USER bash -c "pip install ..."
    ```

    Instead, we need to get the path to the Python executable before calling sudo.
    ```sh
    PYTHON_SRC=$(which python)
    sudo -u USER bash -c "'$PYTHON_SRC' install ..."
    ```

### Skipping installation for the root user if the remote user is not root
This is an opinionated change, but it does align with the recommendation that we do not install pip packages as root. In `install.sh`, the second call to `install-python-keyring.sh` was removed for this reason.

### Additional Tests
We remove the python parameter from the global tests and create our own scenarios which are specific to the artifacts-helper feature. We test for the existence of the keyring packages.