### PR TITLE
(feat) support `pnpm` in artifacts-helper

### DIFF
--- a/src/artifacts-helper/NOTES.md
+++ b/src/artifacts-helper/NOTES.md
@@ -1,8 +1,8 @@
 This installs [Azure Artifacts Credential Provider](https://github.com/microsoft/artifacts-credprovider)
-and optionally configures functions which shadow `dotnet`, `nuget`, `npm`, `yarn`, and `rush` which dynamically sets an authentication token
+and optionally configures functions which shadow `dotnet`, `nuget`, `npm`, `yarn`, `rush`, and `pnpm` which dynamically sets an authentication token
 for pulling artifacts from a feed before running the command.
 
-For `npm`, `yarn`, and `rush` this requires that your `~/.npmrc` file is configured to use the ${ARTIFACTS_ACCESSTOKEN}
+For `npm`, `yarn`, `rush`, and `pnpm` this requires that your `~/.npmrc` file is configured to use the ${ARTIFACTS_ACCESSTOKEN}
 environment variable for the `authToken`. A helper script has been added that you can use to write your `~/.npmrc`
 file during your setup process, though there are many ways you could accomplish this. To use the script, run it like
 this:

--- a/src/artifacts-helper/devcontainer-feature.json
+++ b/src/artifacts-helper/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Azure Artifacts Credential Helper",
     "id": "artifacts-helper",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "description": "Configures Codespace to authenticate with Azure Artifact feeds",
     "options": {
         "nugetURIPrefixes": {
@@ -43,6 +43,11 @@
             "type": "boolean",
             "default": true,
             "description": "Create alias for rush"
+        },
+        "pnpmAlias": {
+            "type": "boolean",
+            "default": true,
+            "description": "Create alias for pnpm"
         },
         "targetFiles": {
             "type": "string",

--- a/src/artifacts-helper/install.sh
+++ b/src/artifacts-helper/install.sh
@@ -10,6 +10,7 @@ ALIAS_NPM="${NPMALIAS:-"true"}"
 ALIAS_YARN="${YARNALIAS:-"true"}"
 ALIAS_NPX="${NPXALIAS:-"true"}"
 ALIAS_RUSH="${RUSHALIAS:-"true"}"
+ALIAS_PNPM="${PNPMALIAS:-"true"}"
 INSTALL_PIP_HELPER="${PYTHON:-"false"}"
 COMMA_SEP_TARGET_FILES="${TARGETFILES:-"DEFAULT"}"
 
@@ -33,6 +34,10 @@ fi
 if [ "${ALIAS_RUSH}" = "true" ]; then
     ALIASES_ARR+=('rush')
     ALIASES_ARR+=('rush-pnpm')
+fi
+if [ "${ALIAS_PNPM}" = "true" ]; then
+    ALIASES_ARR+=('pnpm')
+    ALIASES_ARR+=('pnpx')
 fi
 
 # Source /etc/os-release to get OS info
@@ -93,6 +98,11 @@ cp ./scripts/run-rush.sh /usr/local/bin/run-rush.sh
 chmod +rx /usr/local/bin/run-rush.sh
 cp ./scripts/run-rush-pnpm.sh /usr/local/bin/run-rush-pnpm.sh
 chmod +rx /usr/local/bin/run-rush-pnpm.sh
+
+cp ./scripts/run-pnpm.sh /usr/local/bin/run-pnpm.sh
+chmod +rx /usr/local/bin/run-pnpm.sh
+cp ./scripts/run-pnpx.sh /usr/local/bin/run-pnpx.sh
+chmod +rx /usr/local/bin/run-pnpx.sh
 
 if [ "${INSTALL_PIP_HELPER}" = "true" ]; then
     USER="${_REMOTE_USER}" /tmp/install-python-keyring.sh

--- a/src/artifacts-helper/scripts/run-pnpm.sh
+++ b/src/artifacts-helper/scripts/run-pnpm.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ -f "${HOME}/ado-auth-helper" ]; then
+  export ARTIFACTS_ACCESSTOKEN=$(${HOME}/ado-auth-helper get-access-token)
+fi
+
+# Find the pnpm executable so we do not run the bash alias again
+PNPM_EXE=$(which pnpm)
+
+${PNPM_EXE} "$@"
+EXIT_CODE=$?
+unset PNPM_EXE
+
+if [ -f "${HOME}/ado-auth-helper" ]; then
+    unset ARTIFACTS_ACCESSTOKEN
+fi
+
+exit $EXIT_CODE

--- a/src/artifacts-helper/scripts/run-pnpx.sh
+++ b/src/artifacts-helper/scripts/run-pnpx.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ -f "${HOME}/ado-auth-helper" ]; then
+  export ARTIFACTS_ACCESSTOKEN=$(${HOME}/ado-auth-helper get-access-token)
+fi
+
+# Find the pnpx executable so we do not run the bash alias again
+PNPX_EXE=$(which pnpx)
+
+${PNPX_EXE} "$@"
+EXIT_CODE=$?
+unset PNPX_EXE
+
+if [ -f "${HOME}/ado-auth-helper" ]; then
+    unset ARTIFACTS_ACCESSTOKEN
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
Adds support to the artifacts-helper feature for `pnpm` (and `pnpx`), so that monorepos using pnpm directly can benefit from the same authentication model.