### PR TITLE
Update to use `.zshenv` over `.zshrc`

### DIFF
--- a/src/artifacts-helper/install.sh
+++ b/src/artifacts-helper/install.sh
@@ -118,9 +118,9 @@ fi
 
 if [ "${COMMA_SEP_TARGET_FILES}" = "DEFAULT" ]; then
     if [ "${INSTALL_WITH_SUDO}" = "true" ]; then
-        COMMA_SEP_TARGET_FILES="~/.bashrc,~/.zshrc"
+        COMMA_SEP_TARGET_FILES="~/.bashrc,~/.zshenv"
     else
-        COMMA_SEP_TARGET_FILES="/etc/bash.bashrc,/etc/zsh/zshrc"
+        COMMA_SEP_TARGET_FILES="/etc/bash.bashrc,/etc/zsh/zshenv"
     fi
 fi
 


### PR DESCRIPTION
`.zshenv` is sourced by all zsh shells (interactive/non-interactive/login).
Where `.zshrc` is only sourced by interactive shells.

To prevent users from having to be aware of auth wrappers,
using `.zshenv` will help reduce friction for users.

This should help with #55, but only for zsh.