### PR TITLE
Setup BASH_ENV and zshenv

### DIFF
--- a/src/artifacts-helper/install.sh
+++ b/src/artifacts-helper/install.sh
@@ -118,9 +118,9 @@ fi
 
 if [ "${COMMA_SEP_TARGET_FILES}" = "DEFAULT" ]; then
     if [ "${INSTALL_WITH_SUDO}" = "true" ]; then
-        COMMA_SEP_TARGET_FILES="~/.bashrc,~/.zshrc"
+        COMMA_SEP_TARGET_FILES="~/.bashrc,~/.zshenv"
     else
-        COMMA_SEP_TARGET_FILES="/etc/bash.bashrc,/etc/zsh/zshrc"
+        COMMA_SEP_TARGET_FILES="/etc/bash.bashrc,/etc/zsh/zshenv"
     fi
 fi
 


### PR DESCRIPTION
BASH_ENV is a variable used for identifying a script that should be sourced when launching bash scripts.

zshenv is always sourced by zsh in interactive and non-interactive modes.

This makes it so that the auth wrapping functions are available in bash and zsh scripts.