### PR TITLE
feat(artifacts-helper): add fish shell support for aliases

### DIFF
--- a/src/artifacts-helper/install.sh
+++ b/src/artifacts-helper/install.sh
@@ -136,6 +136,28 @@ for TARGET_FILE in "${TARGET_FILES_ARR[@]}"; do
     fi
 done
 
+# fish shell support
+FISH_FUNCTIONS_DIR=""
+if [ "${INSTALL_WITH_SUDO}" = "true" ]; then
+    FISH_FUNCTIONS_DIR=$(sudo -u ${_REMOTE_USER} bash -c 'echo ~/.config/fish/functions')
+    sudo -u ${_REMOTE_USER} mkdir -p "$FISH_FUNCTIONS_DIR"
+else
+    FISH_FUNCTIONS_DIR="/etc/fish/functions"
+    mkdir -p "$FISH_FUNCTIONS_DIR" 2>/dev/null || true
+fi
+
+for ALIAS in "${ALIASES_ARR[@]}"; do
+    FISH_FUNC_FILE="${FISH_FUNCTIONS_DIR}/${ALIAS}.fish"
+    FISH_FUNC_CONTENT="function ${ALIAS} --wraps=${SHIM_DIRECTORY}${ALIAS}
+    ${SHIM_DIRECTORY}${ALIAS} \$argv
+end"
+    if [ "${INSTALL_WITH_SUDO}" = "true" ]; then
+        sudo -u ${_REMOTE_USER} bash -c "cat > \"$FISH_FUNC_FILE\"" <<< "$FISH_FUNC_CONTENT"
+    else
+        echo "$FISH_FUNC_CONTENT" > "$FISH_FUNC_FILE" 2>/dev/null || true
+    fi
+done
+
 if [ "${INSTALL_WITH_SUDO}" = "true" ]; then
     sudo -u ${_REMOTE_USER} bash -c "/tmp/install-provider.sh ${USENET6}"
 fi


### PR DESCRIPTION
## Summary

This PR adds fish shell support for the artifacts helper shims/aliases.

## Changes

- Creates fish function files in `~/.config/fish/functions/` for each enabled alias
- Supports all existing aliases: `dotnet`, `nuget`, `npm`, `yarn`, `npx`, `rush`, `rush-pnpm`, `pnpm`, `pnpx`
- Respects existing sudo logic for non-root vs root installations

## How it works

For each alias, a fish function file is created (e.g., `dotnet.fish`):

```fish
function dotnet --wraps=/usr/local/share/codespace-shims/dotnet
    /usr/local/share/codespace-shims/dotnet $argv
end