### PR TITLE
Fix artifacts-helper non-root temp file append

### DIFF
--- a/src/artifacts-helper/devcontainer-feature.json
+++ b/src/artifacts-helper/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Azure Artifacts Credential Helper",
     "id": "artifacts-helper",
-    "version": "3.0.8",
+    "version": "3.0.9",
     "description": "Configures Codespace to authenticate with Azure Artifact feeds",
     "options": {
         "nugetURIPrefixes": {

--- a/src/artifacts-helper/install.sh
+++ b/src/artifacts-helper/install.sh
@@ -136,7 +136,7 @@ printf '%s' "$ALIASES_BLOCK" > "$_TEMP_BLOCK"
 
 for TARGET_FILE in "${TARGET_FILES_ARR[@]}"; do
     if [ "${INSTALL_WITH_SUDO}" = "true" ]; then
-        sudo -u "${_REMOTE_USER}" bash -c "cat '$_TEMP_BLOCK' >> $TARGET_FILE"
+        sudo -u "${_REMOTE_USER}" bash -c "cat >> $TARGET_FILE" < "$_TEMP_BLOCK"
     else
         cat "$_TEMP_BLOCK" >> "$TARGET_FILE" || true
     fi

--- a/src/artifacts-helper/install.sh
+++ b/src/artifacts-helper/install.sh
@@ -133,10 +133,11 @@ done
 
 _TEMP_BLOCK=$(mktemp)
 printf '%s' "$ALIASES_BLOCK" > "$_TEMP_BLOCK"
+chmod a+r "$_TEMP_BLOCK"
 
 for TARGET_FILE in "${TARGET_FILES_ARR[@]}"; do
     if [ "${INSTALL_WITH_SUDO}" = "true" ]; then
-        sudo -u "${_REMOTE_USER}" bash -c "cat >> $TARGET_FILE" < "$_TEMP_BLOCK"
+        sudo -u "${_REMOTE_USER}" bash -c "cat '$_TEMP_BLOCK' >> $TARGET_FILE"
     else
         cat "$_TEMP_BLOCK" >> "$TARGET_FILE" || true
     fi

--- a/test/artifacts-helper/scenarios.json
+++ b/test/artifacts-helper/scenarios.json
@@ -59,6 +59,17 @@
             }
         }
     },
+    "test_non_root_install": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "remoteUser": "vscode",
+        "features": {
+            "artifacts-helper": {
+                "dotnetAlias": true,
+                "npmAlias": true,
+                "nugetAlias": true
+            }
+        }
+    },
     "test_fallback_execution": {
         "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {

--- a/test/artifacts-helper/test_non_root_install.sh
+++ b/test/artifacts-helper/test_non_root_install.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib || exit 1
+
+check "non-root bash aliases written" grep -q 'dotnet() { ".*/dotnet" "\$@"; }' /home/vscode/.bashrc
+check "non-root zsh aliases written" grep -q 'npm() { ".*/npm" "\$@"; }' /home/vscode/.zshrc
+
+reportResults


### PR DESCRIPTION
## Summary

- make the root-created aliases temp file readable before appending it as the non-root remote user
- add a non-root install regression scenario for artifacts-helper
- bump artifacts-helper to 3.0.9

Fixes #112

## Validation

- `jq empty test/artifacts-helper/scenarios.json src/artifacts-helper/devcontainer-feature.json`
- `bash -n src/artifacts-helper/install.sh test/artifacts-helper/test_non_root_install.sh test/artifacts-helper/test_shim_integration.sh`
- `git diff --check`
- local permission simulation confirming the previous root-owned mktemp read fails and the `chmod a+r` approach succeeds