### PR TITLE
Fix microsoft-git release version parsing

### DIFF
--- a/src/microsoft-git/devcontainer-feature.json
+++ b/src/microsoft-git/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Microsoft Git for monorepo with GVFS support",
     "id": "microsoft-git",
-    "version": "1.0.9",
+    "version": "1.0.10",
     "description": "A fork of Git containing Microsoft-specific patches",
     "options": {
         "version": {

--- a/src/microsoft-git/install.sh
+++ b/src/microsoft-git/install.sh
@@ -30,6 +30,8 @@ check_packages() {
     fi
 }
 
+MICROSOFT_GIT_VERSION_REGEX='[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?\.vfs\.[0-9]+\.[0-9]+'
+
 export DEBIAN_FRONTEND=noninteractive
 
 if command -v tdnf >/dev/null 2>&1; then
@@ -39,26 +41,30 @@ else
 fi
 
 # Partial version matching
-if [ "$(echo "${GIT_VERSION}" | grep -o '\.' | wc -l)" != "2" ]; then
-    requested_version="${GIT_VERSION}"
+requested_version="${GIT_VERSION#v}"
+if ! echo "${requested_version}" | grep -Eq "^${MICROSOFT_GIT_VERSION_REGEX}$"; then
     if [ "${requested_version}" = "latest" ] || [ "${requested_version}" = "lts" ] || [ "${requested_version}" = "current" ]; then
-        # For latest, lts, and current, use the releases API to get the actual latest release
-        GIT_VERSION="$(curl -sSL -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/microsoft/git/releases/latest" | grep -oP '"tag_name":\s*"v\K[0-9]+\.[0-9]+\.[0-9]+\.vfs\.[0-9]+\.[0-9]+"' | tr -d '"')"
+        # For latest, lts, and current, use the releases API to get the actual latest stable release
+        GIT_VERSION="$(curl -sSL -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/microsoft/git/releases/latest" | sed -nE "s/.*\"tag_name\"[[:space:]]*:[[:space:]]*\"v(${MICROSOFT_GIT_VERSION_REGEX})\".*/\1/p")"
     else
-        # For partial versions, use the existing tags logic
-        version_list="$(curl -sSL -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/microsoft/git/tags?per_page=100" | grep -oP '"name":\s*"v\K[0-9]+\.[0-9]+\.[0-9]+\.vfs\.[0-9]+\.[0-9]+"' | tr -d '"' | sort -rV)"
+        # For partial versions, use the releases API so multi-digit VFS and RC releases are included
+        version_list="$(curl -sSL -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/microsoft/git/releases?per_page=100" | sed -nE "s/.*\"tag_name\"[[:space:]]*:[[:space:]]*\"v(${MICROSOFT_GIT_VERSION_REGEX})\".*/\1/p" | sort -rV | uniq)"
+        escaped_requested_version="$(echo "${requested_version}" | sed -E 's/[][(){}.^$*+?|\\]/\\&/g')"
         set +e
-        GIT_VERSION="$(echo "${version_list}" | grep -E -m 1 "^${requested_version//./\\.}([\\.\\s]|$)")"
+        GIT_VERSION="$(echo "${version_list}" | grep -E -m 1 "^${escaped_requested_version}([.-]|$)")"
         set -e
         if [ -z "${GIT_VERSION}" ] || ! echo "${version_list}" | grep "^${GIT_VERSION//./\\.}$" > /dev/null 2>&1; then
             echo "Invalid git version: ${requested_version}" >&2
             exit 1
         fi
     fi
-    if [ -z "${GIT_VERSION}" ]; then
-        echo "Invalid git version: ${requested_version}" >&2
-        exit 1
-    fi
+else
+    GIT_VERSION="${requested_version}"
+fi
+
+if [ -z "${GIT_VERSION}" ]; then
+    echo "Invalid git version: ${requested_version}" >&2
+    exit 1
 fi
 
 
@@ -86,8 +92,13 @@ ARCH="$(dpkg --print-architecture)"
 DEB_URL="https://github.com/microsoft/git/releases/download/v${GIT_VERSION}/microsoft-git_${GIT_VERSION}_${ARCH}.deb"
 DEB_FILE="microsoft-git_${GIT_VERSION}_${ARCH}.deb"
 
-# Try arch-specific .deb first, fall back to no-arch .deb for older releases
+# Try arch-specific .deb first, fall back to legacy amd64 .deb for older releases
 if ! wget -q "${DEB_URL}" -O "${DEB_FILE}" 2>/dev/null; then
+    if [ "${ARCH}" != "amd64" ]; then
+        echo "Could not download Microsoft Git ${GIT_VERSION} package for architecture ${ARCH}." >&2
+        echo "Older Microsoft Git releases only published legacy amd64 Debian package assets." >&2
+        exit 1
+    fi
     DEB_URL="https://github.com/microsoft/git/releases/download/v${GIT_VERSION}/microsoft-git_${GIT_VERSION}.deb"
     DEB_FILE="microsoft-git_${GIT_VERSION}.deb"
     wget -q "${DEB_URL}" -O "${DEB_FILE}"

--- a/test/microsoft-git/explicit_prerelease.sh
+++ b/test/microsoft-git/explicit_prerelease.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+EXPECTED_VERSION="2.55.0-rc1.vfs.0.0"
+
+check "git version" bash -c "git --version | grep '${EXPECTED_VERSION}'"
+check "scalar available" bash -c "command -v scalar && scalar version"
+
+reportResults

--- a/test/microsoft-git/latest_stable.sh
+++ b/test/microsoft-git/latest_stable.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "git version has vfs" bash -c "git --version | grep 'vfs'"
+check "latest is stable" bash -c "! git --version | grep -E -- '-rc[0-9]+'"
+check "scalar available" bash -c "command -v scalar && scalar version"
+
+reportResults

--- a/test/microsoft-git/multi_digit_vfs.sh
+++ b/test/microsoft-git/multi_digit_vfs.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "git version uses requested series" bash -c "git --version | grep '2.53.0.vfs.0'"
+check "git version has multi-digit vfs revision" bash -c "git --version | grep -E '2\\.53\\.0\\.vfs\\.0\\.[0-9]{2,}'"
+check "scalar available" bash -c "command -v scalar && scalar version"
+
+reportResults

--- a/test/microsoft-git/old_noarch_deb.sh
+++ b/test/microsoft-git/old_noarch_deb.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+EXPECTED_VERSION="2.52.0.vfs.0.4"
+
+check "git version" bash -c "git --version | grep '${EXPECTED_VERSION}'"
+check "scalar available" bash -c "command -v scalar && scalar version"
+
+reportResults

--- a/test/microsoft-git/scenarios.json
+++ b/test/microsoft-git/scenarios.json
@@ -1,0 +1,34 @@
+{
+    "latest_stable": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "microsoft-git": {
+                "version": "latest"
+            }
+        }
+    },
+    "old_noarch_deb": {
+        "image": "mcr.microsoft.com/devcontainers/base@sha256:4511e477aa0ca06a16dd2e70e1c5a540d0f23fbcfeea3b9ee6f8819403d9a602",
+        "features": {
+            "microsoft-git": {
+                "version": "2.52.0.vfs.0.4"
+            }
+        }
+    },
+    "multi_digit_vfs": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "microsoft-git": {
+                "version": "2.53.0.vfs.0"
+            }
+        }
+    },
+    "explicit_prerelease": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "microsoft-git": {
+                "version": "2.55.0-rc1.vfs.0.0"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- support current microsoft/git release tag shapes, including multi-digit VFS revisions and explicit RC versions
- keep latest/current/lts resolving to the latest stable release
- preserve older amd64 legacy Debian package compatibility while avoiding incompatible legacy packages on other architectures
- add targeted microsoft-git scenarios for latest, legacy package, multi-digit VFS, and explicit prerelease installs

## Validation
- bash -n src/microsoft-git/install.sh test/microsoft-git/*.sh
- jq empty src/microsoft-git/devcontainer-feature.json test/microsoft-git/scenarios.json
- devcontainer features test -f microsoft-git --skip-autogenerated .
