### PR TITLE
Add Corepack artifact authentication shim

### DIFF
--- a/src/artifacts-helper/NOTES.md
+++ b/src/artifacts-helper/NOTES.md
@@ -1,5 +1,5 @@
 This installs [Azure Artifacts Credential Provider](https://github.com/microsoft/artifacts-credprovider)
-and optionally configures shims which shadow `dotnet`, `nuget`, `npm`, `yarn`, `rush`, `pnpm`, and `az`.
+and optionally configures shims which shadow `dotnet`, `nuget`, `npm`, `yarn`, `rush`, `pnpm`, `corepack`, and `az`.
 These dynamically set an authentication token for pulling artifacts from a feed before running the command.
 
 The `az` shim specifically intercepts `az account get-access-token` requests and uses the `azure-auth-helper`
@@ -20,7 +20,7 @@ The shim will:
 If `AZURE_DEVOPS_EXT_PAT` is already set, the shim will not overwrite it. If `ado-auth-helper` is not
 available after the timeout, the command will still execute (but may fail to authenticate to Azure DevOps).
 
-For `npm`, `yarn`, `rush`, and `pnpm` this requires that your `~/.npmrc` file is configured to use the ${ARTIFACTS_ACCESSTOKEN}
+For `npm`, `yarn`, `rush`, `pnpm`, and `corepack` this requires that your `~/.npmrc` file is configured to use the ${ARTIFACTS_ACCESSTOKEN}
 environment variable for the `authToken`. A helper script has been added that you can use to write your `~/.npmrc`
 file during your setup process, though there are many ways you could accomplish this. To use the script, run it like
 this:

--- a/src/artifacts-helper/README.md
+++ b/src/artifacts-helper/README.md
@@ -24,6 +24,7 @@ Configures Codespace to authenticate with Azure Artifact feeds
 | npxAlias | Create alias for npx | boolean | true |
 | rushAlias | Create alias for rush | boolean | true |
 | pnpmAlias | Create alias for pnpm | boolean | true |
+| corepackAlias | Create alias for corepack | boolean | true |
 | azAlias | Create alias for az (Azure CLI) | boolean | true |
 | shimDirectory | Directory where the shims will be installed. This must be in $PATH, and needs to be as early as possible in priority for the scripts to override the base executables. | string | /usr/local/share/codespace-shims |
 | targetFiles | Comma separated list of files to write to. Default is '/etc/bash.bashrc,/etc/zsh/zshrc' for root and '~/.bashrc,~/.zshrc' for non-root | string | DEFAULT |
@@ -36,7 +37,7 @@ Configures Codespace to authenticate with Azure Artifact feeds
 - `ms-codespaces-tools.ado-codespaces-auth`
 
 This installs [Azure Artifacts Credential Provider](https://github.com/microsoft/artifacts-credprovider)
-and optionally configures shims which shadow `dotnet`, `nuget`, `npm`, `yarn`, `rush`, `pnpm`, and `az`.
+and optionally configures shims which shadow `dotnet`, `nuget`, `npm`, `yarn`, `rush`, `pnpm`, `corepack`, and `az`.
 These dynamically set an authentication token for pulling artifacts from a feed before running the command.
 
 The `az` shim specifically intercepts `az account get-access-token` requests and uses the `azure-auth-helper`
@@ -57,7 +58,7 @@ The shim will:
 If `AZURE_DEVOPS_EXT_PAT` is already set, the shim will not overwrite it. If `ado-auth-helper` is not
 available after the timeout, the command will still execute (but may fail to authenticate to Azure DevOps).
 
-For `npm`, `yarn`, `rush`, and `pnpm` this requires that your `~/.npmrc` file is configured to use the ${ARTIFACTS_ACCESSTOKEN}
+For `npm`, `yarn`, `rush`, `pnpm`, and `corepack` this requires that your `~/.npmrc` file is configured to use the ${ARTIFACTS_ACCESSTOKEN}
 environment variable for the `authToken`. A helper script has been added that you can use to write your `~/.npmrc`
 file during your setup process, though there are many ways you could accomplish this. To use the script, run it like
 this:

--- a/src/artifacts-helper/devcontainer-feature.json
+++ b/src/artifacts-helper/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Azure Artifacts Credential Helper",
     "id": "artifacts-helper",
-    "version": "3.0.9",
+    "version": "3.1.0",
     "description": "Configures Codespace to authenticate with Azure Artifact feeds",
     "options": {
         "nugetURIPrefixes": {

--- a/src/artifacts-helper/devcontainer-feature.json
+++ b/src/artifacts-helper/devcontainer-feature.json
@@ -49,6 +49,11 @@
             "default": true,
             "description": "Create alias for pnpm"
         },
+        "corepackAlias": {
+            "type": "boolean",
+            "default": true,
+            "description": "Create alias for corepack"
+        },
         "azAlias": {
             "type": "boolean",
             "default": true,

--- a/src/artifacts-helper/install.sh
+++ b/src/artifacts-helper/install.sh
@@ -11,6 +11,7 @@ ALIAS_YARN="${YARNALIAS:-"true"}"
 ALIAS_NPX="${NPXALIAS:-"true"}"
 ALIAS_RUSH="${RUSHALIAS:-"true"}"
 ALIAS_PNPM="${PNPMALIAS:-"true"}"
+ALIAS_COREPACK="${COREPACKALIAS:-"true"}"
 ALIAS_AZ="${AZALIAS:-"true"}"
 INSTALL_PIP_HELPER="${PYTHON:-"false"}"
 SHIM_DIRECTORY="${SHIMDIRECTORY:-"/usr/local/share/codespace-shims/"}"
@@ -39,6 +40,9 @@ fi
 if [ "${ALIAS_PNPM}" = "true" ]; then
     ALIASES_ARR+=('pnpm')
     ALIASES_ARR+=('pnpx')
+fi
+if [ "${ALIAS_COREPACK}" = "true" ]; then
+    ALIASES_ARR+=('corepack')
 fi
 if [ "${ALIAS_AZ}" = "true" ]; then
     ALIASES_ARR+=('az')

--- a/src/artifacts-helper/scripts/corepack
+++ b/src/artifacts-helper/scripts/corepack
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# If ACTIONS_ID_TOKEN_REQUEST_URL is set, we're in GitHub Actions - skip Azure DevOps setup
+if [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL}" ]; then
+  source "$(dirname "$0")"/resolve-shim.sh
+  COREPACK_EXE="$(resolve_shim)"
+  "${COREPACK_EXE}" "$@"
+  exit $?
+fi
+
+source "$(dirname "$0")"/auth-ado.sh
+source "$(dirname "$0")"/resolve-shim.sh
+
+COREPACK_EXE="$(resolve_shim)"
+ARTIFACTS_ACCESSTOKEN="${ARTIFACTS_ACCESSTOKEN:-}" "${COREPACK_EXE}" "$@"

--- a/test/artifacts-helper/test_fallback_execution.sh
+++ b/test/artifacts-helper/test_fallback_execution.sh
@@ -28,6 +28,14 @@ check "npm command executes without auth helper" bash -c '
     timeout 10 /usr/local/share/codespace-shims/npm --version 2>&1 | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+" && echo "SUCCESS" || echo "FAILED"
 ' | grep -q "SUCCESS"
 
+# Corepack must pass the token environment to package managers it dispatches to.
+check "corepack command executes without auth helper" bash -c '
+    export HOME='"$TEST_HOME"'
+    export MAX_WAIT=5
+
+    timeout 10 /usr/local/share/codespace-shims/corepack --version 2>&1 | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+" && echo "SUCCESS" || echo "FAILED"
+' | grep -q "SUCCESS"
+
 # Test that nuget can be called (may not return version without auth, but should not crash)
 check "nuget command attempts to execute without auth helper" bash -c '
     export HOME='"$TEST_HOME"'

--- a/test/artifacts-helper/test_shim_integration.sh
+++ b/test/artifacts-helper/test_shim_integration.sh
@@ -20,18 +20,21 @@ check "dotnet shim handles missing auth helper" bash -c '
 # Test that the shim scripts properly source auth-ado.sh
 check "dotnet shim sources auth-ado.sh" grep -q "source.*auth-ado.sh" /usr/local/share/codespace-shims/dotnet
 check "npm shim sources auth-ado.sh" grep -q "source.*auth-ado.sh" /usr/local/share/codespace-shims/npm
+check "corepack shim sources auth-ado.sh" grep -q "source.*auth-ado.sh" /usr/local/share/codespace-shims/corepack
 
 # Verify the shim directory is in PATH
 check "shim directory in PATH" bash -c '[[ ":$PATH:" == *":/usr/local/share/codespace-shims:"* ]]'
 
 # Verify that shell function shims are written to rc files (not just shim scripts)
 check "npm shell function written to bash.bashrc" grep -q "npm()" /etc/bash.bashrc
+check "corepack shell function written to bash.bashrc" grep -q "corepack()" /etc/bash.bashrc
 check "dotnet shell function written to bash.bashrc" grep -q "dotnet()" /etc/bash.bashrc
 check "npm shell function on its own line in bash.bashrc" grep -q "^npm()" /etc/bash.bashrc
 
 # Verify aliases include proper quoting and argument passing ($@)
 check "dotnet alias has quoted path and passes args" grep -q 'dotnet() { ".*/dotnet" "\$@"; }' /etc/bash.bashrc
 check "npm alias has quoted path and passes args" grep -q 'npm() { ".*/npm" "\$@"; }' /etc/bash.bashrc
+check "corepack alias has quoted path and passes args" grep -q 'corepack() { ".*/corepack" "\$@"; }' /etc/bash.bashrc
 
 # Verify newlines between shim definitions (each function should be on its own line)
 check "each shim function is on its own line" bash -c '


### PR DESCRIPTION
## Summary

- add an Azure Artifacts authentication shim for `corepack` commands
- expose the default-enabled `corepackAlias` feature option
- bump the backward-compatible feature release to `3.1.0`
- add Corepack shim installation and fallback execution coverage

## Validation

- `bash -n src/artifacts-helper/install.sh src/artifacts-helper/scripts/corepack test/artifacts-helper/test_shim_integration.sh test/artifacts-helper/test_fallback_execution.sh`
- `jq empty src/artifacts-helper/devcontainer-feature.json`
- `git diff --check`

The Dev Container CLI is not installed locally, so the feature integration scenario was not run.
